### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   "license": "MIT",
   "repository": "kborchers/react-globalize",
   "bugs": "https://github.com/kborchers/react-globalize/issues",
-  "devDependencies": {
-    "browserify": "~9.0.3"
+  "dependencies": {
+    "globalize": ">= 1.0.0",
+    "react": ">= 0.12.0"
   },
   "peerDependencies": {
-    "react": "~0.13.1"
+    "globalize": ">= 1.0.0",
+    "react": ">= 0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "repository": "kborchers/react-globalize",
   "bugs": "https://github.com/kborchers/react-globalize/issues",
   "dependencies": {
-    "globalize": ">= 1.0.0",
-    "react": ">= 0.12.0"
+    "globalize": "1.*.*",
+    "react": "0.*.*"
   },
   "peerDependencies": {
-    "globalize": ">= 1.0.0",
-    "react": ">= 0.12.0"
+    "globalize": "1.*.*",
+    "react": "0.*.*"
   }
 }


### PR DESCRIPTION
- More permissive `react` and `globalize` dependency range;
- Bump `globalize` up to 1.0.0;
- Browserify is used in the examples, not by this package;