### PR TITLE
Messages: Support React elements in the message

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -9,6 +9,9 @@ function generator(fn, argArray, options) {
     var Fn = capitalizeFirstLetter(fn);
     options = options || {};
     var beforeFormat = options.beforeFormat || function() {};
+    var afterFormat = options.afterFormat || function(formattedValue) {
+        return formattedValue;
+    }
     return {
         displayName: Fn,
         format: function() {
@@ -30,7 +33,7 @@ function generator(fn, argArray, options) {
             }
 
             beforeFormat.call(this);
-            return React.DOM.span(null, this.format());
+            return React.DOM.span(null, afterFormat.call(this, this.format()));
         }
     }
 };

--- a/src/message.js
+++ b/src/message.js
@@ -101,7 +101,7 @@ function replaceElements(componentProps, formatted) {
             var element = elements[key];
 
             ret.forEach(function(string, i) {
-                var aux;
+                var aux, contents, regexp, regexp2;
 
                 // Insert array into the correct ret position.
                 function replaceRetItem(array) {
@@ -118,6 +118,20 @@ function replaceElements(componentProps, formatted) {
                     aux = spreadElementsInBetweenItems(aux, element);
                     replaceRetItem(aux);
                     return; // continue;
+                }
+
+                // Start-end tags, e.g., `[foo]content[/foo]`.
+                regexp = new RegExp("\\[" + key + "\\][\\s\\S]*?\\[\\/" + key + "\\]", "g");
+                regexp2 = new RegExp("\\[" + key + "\\]([\\s\\S]*?)\\[\\/" + key + "\\]");
+                aux = string.split(regexp);
+                if (aux.length > 1) {
+                    contents = string.match(regexp).map(function(content) {
+                        return content.replace(regexp2, "$1");
+                    });
+                    aux = spreadElementsInBetweenItems(aux, function(i) {
+                        return React.cloneElement(element, {}, contents[i]);
+                    });
+                    replaceRetItem(aux);
                 }
             });
 


### PR DESCRIPTION
TODO:
- [x] Documentation

This commit allows React elements to be used in the translated message by replacing the placeholder with the passed element. For example:
- https://github.com/rxaviers/todomvc/blob/react-globalize/examples/react-globalize/src/info.jsx#L23-L27
- https://github.com/rxaviers/yarsk/blob/react-globalize/app/components/Application/index.jsx#L69-L79