### PR TITLE
remove separate dependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,6 @@
   "license": "MIT",
   "repository": "kborchers/react-globalize",
   "bugs": "https://github.com/kborchers/react-globalize/issues",
-  "dependencies": {
-    "globalize": ">= 1.0.0",
-    "react": ">= 0.13.0 < 1.0.0"
-  },
   "peerDependencies": {
     "globalize": ">= 1.0.0 || 1.1.0-alpha - 1.1.x",
     "react": ">= 0.13.0 < 1.0.0"


### PR DESCRIPTION
`package.json` currently duplicates `dependencies` and `peerDependencies`, which caused me some issues installing (in npm 2), perhaps because the version of globalize didn't match between the two.

I think it should be safe to delete the `dependencies` block entirely and just rely on the top-level application to provide react and globalize.