### PR TITLE
Fix example, and related bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ The date object to be formatted. Required.
 
 #### Props
 
-- **value** - required
- - The date object to be formatted
 - **options**
  - An optional set of options which defines how to format the date. See the [dateFormatter][] docs in Globalize for more info on supported patterns
 - **locale** - optional
@@ -214,8 +212,6 @@ The number to be formatted. Required.
 
 #### Props
 
-- **value** - required
- - The number to be formatted
 - **options**
  - An optional set of options to further format the value. See the [numberFormatter][] docs in Globalize for more info on specific options
 - **locale** - optional

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+app.js
+react-globalize

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ Install
 -------
 These instructions assume you have node and npm installed. For help, see the [npm docs](https://docs.npmjs.com/getting-started/installing-node)
 
-1. Run `npm install`
+1. Build react-globalize (`cp .. && grunt`)
+1. Run `npm install` in this directory
 2. Run `npm run-script build` to generate the built JS file
 3. Open browser and navigate to `react-globalize/examples/index.html`

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Install
 -------
 These instructions assume you have node and npm installed. For help, see the [npm docs](https://docs.npmjs.com/getting-started/installing-node)
 
-1. Build react-globalize (`cp .. && grunt`)
-1. Run `npm install` in this directory
-2. Run `npm run-script build` to generate the built JS file
-3. Open browser and navigate to `react-globalize/examples/index.html`
+1. Build react-globalize (`cd .. && grunt`)
+2. Run `npm install` in this directory
+3. Run `npm run-script build` to generate the built JS file
+4. Open browser and navigate to `react-globalize/examples/index.html`

--- a/examples/components/currency.js
+++ b/examples/components/currency.js
@@ -23,25 +23,25 @@ module.exports = React.createClass({
                     </select>
                 </div>
                 <br/>
-                USD, 150, locale default - <FormatCurrency locale={this.state.locale} currency="USD" value={150} />
+                USD, 150, locale default - <FormatCurrency locale={this.state.locale} currency="USD">{150}</FormatCurrency>
                 <br/>
-                USD, -150, style: "accounting" - <FormatCurrency locale={this.state.locale} currency="USD" value={-150} options={{ style: "accounting" }} />
+                USD, -150, style: "accounting" - <FormatCurrency locale={this.state.locale} currency="USD" options={{ style: "accounting" }}>{-150}</FormatCurrency>
                 <br/>
-                USD, 150, style: "name" - <FormatCurrency locale={this.state.locale} currency="USD" value={150} options={{ style: "name" }} />
+                USD, 150, style: "name" - <FormatCurrency locale={this.state.locale} currency="USD" options={{ style: "name" }}>{150}</FormatCurrency>
                 <br/>
-                USD, 150, style: "code" - <FormatCurrency locale={this.state.locale} currency="USD" value={150} options={{ style: "code" }} />
+                USD, 150, style: "code" - <FormatCurrency locale={this.state.locale} currency="USD" options={{ style: "code" }}>{150}</FormatCurrency>
                 <br/>
-                USD, 1.491, round: "ceil" - <FormatCurrency locale={this.state.locale} currency="USD" value={1.491} options={{ round: "ceil" }} />
+                USD, 1.491, round: "ceil" - <FormatCurrency locale={this.state.locale} currency="USD" options={{ round: "ceil" }}>{1.491}</FormatCurrency>
                 <br/>
-                EUR, 150, locale default - <FormatCurrency locale={this.state.locale} currency="EUR" value={150} />
+                EUR, 150, locale default - <FormatCurrency locale={this.state.locale} currency="EUR">{150}</FormatCurrency>
                 <br/>
-                EUR, -150, style: "accounting" - <FormatCurrency locale={this.state.locale} currency="EUR" value={-150} options={{ style: "accounting" }} />
+                EUR, -150, style: "accounting" - <FormatCurrency locale={this.state.locale} currency="EUR" options={{ style: "accounting" }}>{-150}</FormatCurrency>
                 <br/>
-                EUR, 150, style: "name" - <FormatCurrency locale={this.state.locale} currency="EUR" value={150} options={{ style: "name" }} />
+                EUR, 150, style: "name" - <FormatCurrency locale={this.state.locale} currency="EUR" options={{ style: "name" }}>{150}</FormatCurrency>
                 <br/>
-                EUR, 150, style: "code" - <FormatCurrency locale={this.state.locale} currency="EUR" value={150} options={{ style: "code" }} />
+                EUR, 150, style: "code" - <FormatCurrency locale={this.state.locale} currency="EUR" options={{ style: "code" }}>{150}</FormatCurrency>
                 <br/>
-                EUR, 1.491, round: "ceil" - <FormatCurrency locale={this.state.locale} currency="EUR" value={1.491} options={{ round: "ceil" }} />
+                EUR, 1.491, round: "ceil" - <FormatCurrency locale={this.state.locale} currency="EUR" options={{ round: "ceil" }}>{1.491}</FormatCurrency>
             </div>
         );
     }

--- a/examples/components/dates.js
+++ b/examples/components/dates.js
@@ -23,13 +23,13 @@ module.exports = React.createClass({
                     </select>
                 </div>
                 <br/>
-                "GyMMMd" - <FormatDate locale={this.state.locale} value={new Date()} pattern="GyMMMd" />
+                "GyMMMd" - <FormatDate locale={this.state.locale} pattern="GyMMMd">{new Date()}</FormatDate>
                 <br/>
-                date: "medium" - <FormatDate locale={this.state.locale} value={new Date()} pattern={{ date: "medium" }} />
+                date: "medium" - <FormatDate locale={this.state.locale} pattern={{ date: "medium" }}>{new Date()}</FormatDate>
                 <br/>
-                time: "medium" - <FormatDate locale={this.state.locale} value={new Date()} pattern={{ time: "medium" }} />
+                time: "medium" - <FormatDate locale={this.state.locale} pattern={{ time: "medium" }}>{new Date()}</FormatDate>
                 <br/>
-                datetime: "medium" - <FormatDate locale={this.state.locale} value={new Date()} pattern={{ datetime: 'medium' }} />
+                datetime: "medium" - <FormatDate locale={this.state.locale} pattern={{ datetime: 'medium' }}>{new Date()}</FormatDate>
             </div>
         );
     }

--- a/examples/components/messages.js
+++ b/examples/components/messages.js
@@ -27,6 +27,12 @@ module.exports = React.createClass({
                 hi - <FormatMessage locale={this.state.locale} path="salutations/hi" />
                 <br/>
                 bye - <FormatMessage locale={this.state.locale} path="salutations/bye" />
+                <h3>Simple default message</h3>
+                <FormatMessage locale={this.state.locale}>Hi</FormatMessage>
+                <br/>
+                <FormatMessage locale={this.state.locale}>Bye</FormatMessage>
+                <br/>
+                <FormatMessage locale={this.state.locale}>Hi/Bye</FormatMessage>
                 <h3>Variable Replacement</h3>
                 ["Wolfgang", "Amadeus", "Mozart"] - <FormatMessage locale={this.state.locale} path="variables/hello" variables={["Wolfgang", "Amadeus", "Mozart"]} />
                 <br/>

--- a/examples/components/numbers.js
+++ b/examples/components/numbers.js
@@ -23,15 +23,16 @@ module.exports = React.createClass({
                     </select>
                 </div>
                 <br/>
-                pi, no options - <FormatNumber locale={this.state.locale} value={Math.PI} />
+                pi, no options - <FormatNumber locale={this.state.locale}>{Math.PI}</FormatNumber>
                 <br/>
-                pi, maximumFractionDigits: 5 - <FormatNumber locale={this.state.locale} value={Math.PI} options={{ maximumFractionDigits: 5 }} />
+                pi, maximumFractionDigits: 5 - <FormatNumber locale={this.state.locale} options={{ maximumFractionDigits: 5 }}>{Math.PI}</FormatNumber>
                 <br/>
-                pi, round: 'floor' - <FormatNumber locale={this.state.locale} value={Math.PI} options={{ round: 'floor' }} />
+                pi, round: 'floor' - <FormatNumber locale={this.state.locale} options={{ round: 'floor' }}>{Math.PI}</FormatNumber>
                 <br/>
-                10000, minimumFractionDigits: 2 - <FormatNumber locale={this.state.locale} value={10000} options={{ minimumFractionDigits: 2 }} />
+                10000, minimumFractionDigits: 2 - <FormatNumber locale={this.state.locale} options={{ minimumFractionDigits: 2 }}>{10000}</FormatNumber>
                 <br/>
-                0.5, style: 'percent' - <FormatNumber locale={this.state.locale} value={0.5} options={{ style: 'percent' }} />
+                0.5, style: 'percent' - <FormatNumber locale={this.state.locale} options={{ style: 'percent' }}>{0.5}</FormatNumber>
+                <br/>
             </div>
         );
     }

--- a/examples/index.js
+++ b/examples/index.js
@@ -39,6 +39,10 @@ var messages = {
         ]
     },
     "pt-BR": {
+        // default message examples
+        "Hi": "Oi",
+        "Bye": "Tchau",
+        "Hi|Bye": "Oi/Tchau",
         salutations: {
             hi: "Oi",
             bye: "Tchau"

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,6 +13,6 @@
     "globalize": "~1.0.0-alpha.18"
   },
   "scripts": {
-    "build": "cp -f ../index.js react-globalize.js && browserify --debug --transform reactify index.js > app.js"
+    "build": "mkdir -p react-globalize && cp ../dist/*.js react-globalize/ && browserify --debug --transform reactify index.js > app.js"
   }
 }

--- a/src/message.js
+++ b/src/message.js
@@ -49,6 +49,7 @@ function messageSetup(componentProps, instance, args) {
 
     // Set path - path as props supercedes default value
     if (pathProperty) {
+        args[0] = pathProperty;
         path = pathProperty.split("/");
     } else {
         defaultMessage = getDefaultMessage(children);


### PR DESCRIPTION
I wanted to use the example in this repo to reproduce some issues we're running into, but it wasn't working when I tried - it seems to have been broken when the code switched from one file to separate ES6 modules. My changes here are, roughly:

- [x] change `example/package.json` to move the dependencies correctly, and detail the steps in `example/README.md`
- [x] modify the example `FormatCurrency`, `FormatNumber` and `FormatDate` components to use children as value, rather than a value prop, as value as prop no longer works. I also updated the README to reflect this.
- [x] some larger changes to `src/message.js` to ensure that paths work, that is:
```
<FormatMessage path="salutations/hi" />
```
continues to work, as well as
```
<FormatMessage>Hi</FormatMessage>
```
and the edge case of "default message that looks like a path", e.g.
```
<FormatMessage>Hi/Bye</FormatMessage>
```